### PR TITLE
Allow EZPaS to work on 1.16.3

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,7 +32,7 @@
   "depends": {
     "fabricloader": ">=0.7.4",
     "fabric": "*",
-    "minecraft": "1.16.2"
+    "minecraft": ">=1.16.2"
   },
   "suggests": {
     "flamingo": "*"


### PR DESCRIPTION
1.16.3 didn't have any important changes